### PR TITLE
Avoid Underlinking

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,6 +14,11 @@ then
   find $SRC_DIR/utils -name "*.py" -exec 2to3 -w -n {} \;
 fi
 
+# avoid linker issues with out dependencies (blosc, bzip2) in
+# downstream packages
+# https://github.com/conda/conda-docs/pull/624
+autoreconf -vfi
+
 # configure
 export LIBRARY_PATH="$PREFIX/lib"
 export CFLAGS="-fPIC"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1002
+  number: 1003
   skip: True  # [win]
 
 requirements:
@@ -21,12 +21,16 @@ requirements:
     - {{ compiler('cxx') }}
 #   - {{ compiler('fortran') }}
     - python
+    - libtool
+    - autoconf
+    - automake
+    - make
+    - pkg-config
   host:
     - blosc
     - bzip2
     - hdf5
     - zlib
-    - pkgconfig
   run:
     - blosc
     - bzip2


### PR DESCRIPTION
Avoid missing dependencies in downstream packages (https://github.com/conda-forge/openpmd-api-feedstock/pull/11) by using anaconda libtool.

See https://github.com/conda/conda-docs/pull/624