### PR TITLE
Fix Rpath Linker Flags

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
-if [ "$(uname)" == "Darwin" ]; then
+if [[ ${target_platform} =~ osx.* ]]; then
     export CXX="${CXX} -stdlib=libc++"
     export LDFLAGS="${LDFLAGS} -Wl,-rpath,$PREFIX/lib"
 
     # remove -lrt
     sed -i '.bak' 's/ -lrt//g' $SRC_DIR/wrappers/numpy/Makefile
+else
+    # downstream linkage with shared libs to our dependencies
+    # https://github.com/conda-forge/adios-feedstock/pull/6#issuecomment-432995338
+    export LDFLAGS="${LDFLAGS} -Wl,-rpath-link,${PREFIX}/lib"
 fi
 
 # Python3 fixes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1003
+  number: 1004
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
Avoid downstream linker issues against our dependencies.

See: https://github.com/conda-forge/adios-feedstock/pull/6#issuecomment-432995338