### PR TITLE
Revert Rpath/Link Changes

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,10 +6,6 @@ if [[ ${target_platform} =~ osx.* ]]; then
 
     # remove -lrt
     sed -i '.bak' 's/ -lrt//g' $SRC_DIR/wrappers/numpy/Makefile
-else
-    # downstream linkage with shared libs to our dependencies
-    # https://github.com/conda-forge/adios-feedstock/pull/6#issuecomment-432995338
-    export LDFLAGS="${LDFLAGS} -Wl,-rpath-link,${PREFIX}/lib"
 fi
 
 # Python3 fixes
@@ -17,11 +13,6 @@ if [[ "${PY_VER}" =~ 3 ]]
 then
   find $SRC_DIR/utils -name "*.py" -exec 2to3 -w -n {} \;
 fi
-
-# avoid linker issues with out dependencies (blosc, bzip2) in
-# downstream packages
-# https://github.com/conda/conda-docs/pull/624
-autoreconf -vfi
 
 # configure
 export LIBRARY_PATH="$PREFIX/lib"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1004
+  number: 1005
   skip: True  # [win]
 
 requirements:
@@ -21,11 +21,7 @@ requirements:
     - {{ compiler('cxx') }}
 #   - {{ compiler('fortran') }}
     - python
-    - libtool
-    - autoconf
-    - automake
     - make
-    - pkg-config
   host:
     - blosc
     - bzip2


### PR DESCRIPTION
Did not improve the downstream situation.
Reverts #6 and #7, but keeps the new `${target_platform} =~ osx.*` formalism.

Problem solved downstream with `-Wl,-rpath-link` to prefix: https://github.com/conda-forge/openpmd-api-feedstock/pull/11