### PR TITLE
stdlib on osx: fixed

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,7 +13,7 @@ then
 fi
 
 # configure does not pass this properly in all cases
-export CFLAGS="-fPIC"
+export CFLAGS="${CFLAGS} -fPIC"
 
 # re-create configuration files (autotools)
 #   also forces taking conda-forge libtool

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
 if [[ ${target_platform} =~ osx.* ]]; then
-    export CXX="${CXX} -stdlib=libc++"
     export LDFLAGS="${LDFLAGS} -Wl,-rpath,$PREFIX/lib"
-
-    # remove -lrt
-    sed -i '.bak' 's/ -lrt//g' $SRC_DIR/wrappers/numpy/Makefile
+else
+    export LDFLAGS="${LDFLAGS} -Wl,-rpath-link,${PREFIX}/lib"
 fi
 
 # Python3 fixes
@@ -14,8 +12,7 @@ then
   find $SRC_DIR/utils -name "*.py" -exec 2to3 -w -n {} \;
 fi
 
-# configure
-export LIBRARY_PATH="$PREFIX/lib"
+# configure does not pass this properly in all cases
 export CFLAGS="-fPIC"
 
 # re-create configuration files (autotools)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - python3interp.patch
 
 build:
-  number: 1006
+  number: 1007
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
stdlib should not manually be fiddled with anymore

Remove `LIBRARY_PATH` fiddling with fix from #7

Do not overwrite `CFLAGS` (but extend)