### PR TITLE
MPI Variants

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -6,10 +6,18 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_c_compilergcccxx_compilergxxtarget_platformlinux-64:
-        CONFIG: linux_c_compilergcccxx_compilergxxtarget_platformlinux-64
-      linux_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformlinux-64:
-        CONFIG: linux_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformlinux-64
+      linux_c_compilergcccxx_compilergxxmpimpichtarget_platformlinux-64:
+        CONFIG: linux_c_compilergcccxx_compilergxxmpimpichtarget_platformlinux-64
+      linux_c_compilergcccxx_compilergxxmpinompitarget_platformlinux-64:
+        CONFIG: linux_c_compilergcccxx_compilergxxmpinompitarget_platformlinux-64
+      linux_c_compilergcccxx_compilergxxmpiopenmpitarget_platformlinux-64:
+        CONFIG: linux_c_compilergcccxx_compilergxxmpiopenmpitarget_platformlinux-64
+      linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpimpichtarget_platformlinux-64:
+        CONFIG: linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpimpichtarget_platformlinux-64
+      linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpinompitarget_platformlinux-64:
+        CONFIG: linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpinompitarget_platformlinux-64
+      linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpiopenmpitarget_platformlinux-64:
+        CONFIG: linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpiopenmpitarget_platformlinux-64
   steps:
   - script: |
       sudo pip install --upgrade pip

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -6,10 +6,18 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      osx_c_compilerclangcxx_compilerclangxxtarget_platformosx-64:
-        CONFIG: osx_c_compilerclangcxx_compilerclangxxtarget_platformosx-64
-      osx_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformosx-64:
-        CONFIG: osx_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformosx-64
+      osx_c_compilerclangcxx_compilerclangxxmpimpichtarget_platformosx-64:
+        CONFIG: osx_c_compilerclangcxx_compilerclangxxmpimpichtarget_platformosx-64
+      osx_c_compilerclangcxx_compilerclangxxmpinompitarget_platformosx-64:
+        CONFIG: osx_c_compilerclangcxx_compilerclangxxmpinompitarget_platformosx-64
+      osx_c_compilerclangcxx_compilerclangxxmpiopenmpitarget_platformosx-64:
+        CONFIG: osx_c_compilerclangcxx_compilerclangxxmpiopenmpitarget_platformosx-64
+      osx_c_compilertoolchain_ccxx_compilertoolchain_cxxmpimpichtarget_platformosx-64:
+        CONFIG: osx_c_compilertoolchain_ccxx_compilertoolchain_cxxmpimpichtarget_platformosx-64
+      osx_c_compilertoolchain_ccxx_compilertoolchain_cxxmpinompitarget_platformosx-64:
+        CONFIG: osx_c_compilertoolchain_ccxx_compilertoolchain_cxxmpinompitarget_platformosx-64
+      osx_c_compilertoolchain_ccxx_compilertoolchain_cxxmpiopenmpitarget_platformosx-64:
+        CONFIG: osx_c_compilertoolchain_ccxx_compilertoolchain_cxxmpiopenmpitarget_platformosx-64
 
   steps:
   # TODO: Fast finish on azure pipelines?

--- a/.ci_support/linux_c_compilergcccxx_compilergxxmpimpichtarget_platformlinux-64.yaml
+++ b/.ci_support/linux_c_compilergcccxx_compilergxxmpimpichtarget_platformlinux-64.yaml
@@ -1,0 +1,32 @@
+build_number_decrement:
+- '0'
+bzip2:
+- '1'
+c_compiler:
+- gcc
+channel_sources:
+- conda-forge/label/gcc7,defaults
+channel_targets:
+- conda-forge gcc7
+cxx_compiler:
+- gxx
+docker_image:
+- condaforge/linux-anvil-comp7
+mpi:
+- mpich
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  zlib:
+    max_pin: x.x
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler
+  - cxx_compiler
+  - channel_sources
+  - channel_targets
+  - docker_image
+  - build_number_decrement
+zlib:
+- '1.2'

--- a/.ci_support/linux_c_compilergcccxx_compilergxxmpinompitarget_platformlinux-64.yaml
+++ b/.ci_support/linux_c_compilergcccxx_compilergxxmpinompitarget_platformlinux-64.yaml
@@ -1,0 +1,32 @@
+build_number_decrement:
+- '0'
+bzip2:
+- '1'
+c_compiler:
+- gcc
+channel_sources:
+- conda-forge/label/gcc7,defaults
+channel_targets:
+- conda-forge gcc7
+cxx_compiler:
+- gxx
+docker_image:
+- condaforge/linux-anvil-comp7
+mpi:
+- nompi
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  zlib:
+    max_pin: x.x
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler
+  - cxx_compiler
+  - channel_sources
+  - channel_targets
+  - docker_image
+  - build_number_decrement
+zlib:
+- '1.2'

--- a/.ci_support/linux_c_compilergcccxx_compilergxxmpiopenmpitarget_platformlinux-64.yaml
+++ b/.ci_support/linux_c_compilergcccxx_compilergxxmpiopenmpitarget_platformlinux-64.yaml
@@ -1,0 +1,32 @@
+build_number_decrement:
+- '0'
+bzip2:
+- '1'
+c_compiler:
+- gcc
+channel_sources:
+- conda-forge/label/gcc7,defaults
+channel_targets:
+- conda-forge gcc7
+cxx_compiler:
+- gxx
+docker_image:
+- condaforge/linux-anvil-comp7
+mpi:
+- openmpi
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  zlib:
+    max_pin: x.x
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler
+  - cxx_compiler
+  - channel_sources
+  - channel_targets
+  - docker_image
+  - build_number_decrement
+zlib:
+- '1.2'

--- a/.ci_support/linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpimpichtarget_platformlinux-64.yaml
+++ b/.ci_support/linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpimpichtarget_platformlinux-64.yaml
@@ -1,0 +1,32 @@
+build_number_decrement:
+- '1000'
+bzip2:
+- '1'
+c_compiler:
+- toolchain_c
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- toolchain_cxx
+docker_image:
+- condaforge/linux-anvil
+mpi:
+- mpich
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  zlib:
+    max_pin: x.x
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler
+  - cxx_compiler
+  - channel_sources
+  - channel_targets
+  - docker_image
+  - build_number_decrement
+zlib:
+- '1.2'

--- a/.ci_support/linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpinompitarget_platformlinux-64.yaml
+++ b/.ci_support/linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpinompitarget_platformlinux-64.yaml
@@ -1,19 +1,19 @@
 build_number_decrement:
-- '0'
+- '1000'
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- toolchain_c
 channel_sources:
-- conda-forge/label/gcc7,defaults
+- conda-forge,defaults
 channel_targets:
-- conda-forge gcc7
+- conda-forge main
 cxx_compiler:
-- gxx
+- toolchain_cxx
 docker_image:
-- condaforge/linux-anvil-comp7
-hdf5:
-- 1.10.4
+- condaforge/linux-anvil
+mpi:
+- nompi
 pin_run_as_build:
   bzip2:
     max_pin: x

--- a/.ci_support/linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpiopenmpitarget_platformlinux-64.yaml
+++ b/.ci_support/linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpiopenmpitarget_platformlinux-64.yaml
@@ -12,8 +12,8 @@ cxx_compiler:
 - toolchain_cxx
 docker_image:
 - condaforge/linux-anvil
-hdf5:
-- 1.10.4
+mpi:
+- openmpi
 pin_run_as_build:
   bzip2:
     max_pin: x

--- a/.ci_support/osx_c_compilerclangcxx_compilerclangxxmpimpichtarget_platformosx-64.yaml
+++ b/.ci_support/osx_c_compilerclangcxx_compilerclangxxmpimpichtarget_platformosx-64.yaml
@@ -1,0 +1,35 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+build_number_decrement:
+- '0'
+bzip2:
+- '1'
+c_compiler:
+- clang
+channel_sources:
+- conda-forge/label/gcc7,defaults
+channel_targets:
+- conda-forge gcc7
+cxx_compiler:
+- clangxx
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- mpich
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  zlib:
+    max_pin: x.x
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler
+  - cxx_compiler
+  - channel_sources
+  - channel_targets
+  - build_number_decrement
+zlib:
+- '1.2'

--- a/.ci_support/osx_c_compilerclangcxx_compilerclangxxmpinompitarget_platformosx-64.yaml
+++ b/.ci_support/osx_c_compilerclangcxx_compilerclangxxmpinompitarget_platformosx-64.yaml
@@ -1,0 +1,35 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+build_number_decrement:
+- '0'
+bzip2:
+- '1'
+c_compiler:
+- clang
+channel_sources:
+- conda-forge/label/gcc7,defaults
+channel_targets:
+- conda-forge gcc7
+cxx_compiler:
+- clangxx
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- nompi
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  zlib:
+    max_pin: x.x
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler
+  - cxx_compiler
+  - channel_sources
+  - channel_targets
+  - build_number_decrement
+zlib:
+- '1.2'

--- a/.ci_support/osx_c_compilerclangcxx_compilerclangxxmpiopenmpitarget_platformosx-64.yaml
+++ b/.ci_support/osx_c_compilerclangcxx_compilerclangxxmpiopenmpitarget_platformosx-64.yaml
@@ -1,0 +1,35 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+build_number_decrement:
+- '0'
+bzip2:
+- '1'
+c_compiler:
+- clang
+channel_sources:
+- conda-forge/label/gcc7,defaults
+channel_targets:
+- conda-forge gcc7
+cxx_compiler:
+- clangxx
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- openmpi
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  zlib:
+    max_pin: x.x
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler
+  - cxx_compiler
+  - channel_sources
+  - channel_targets
+  - build_number_decrement
+zlib:
+- '1.2'

--- a/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxmpimpichtarget_platformosx-64.yaml
+++ b/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxmpimpichtarget_platformosx-64.yaml
@@ -1,0 +1,35 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+build_number_decrement:
+- '1000'
+bzip2:
+- '1'
+c_compiler:
+- toolchain_c
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- toolchain_cxx
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- mpich
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  zlib:
+    max_pin: x.x
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler
+  - cxx_compiler
+  - channel_sources
+  - channel_targets
+  - build_number_decrement
+zlib:
+- '1.2'

--- a/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxmpinompitarget_platformosx-64.yaml
+++ b/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxmpinompitarget_platformosx-64.yaml
@@ -12,12 +12,12 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - toolchain_cxx
-hdf5:
-- 1.10.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+mpi:
+- nompi
 pin_run_as_build:
   bzip2:
     max_pin: x

--- a/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxmpiopenmpitarget_platformosx-64.yaml
+++ b/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxmpiopenmpitarget_platformosx-64.yaml
@@ -1,23 +1,23 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 build_number_decrement:
-- '0'
+- '1000'
 bzip2:
 - '1'
 c_compiler:
-- clang
+- toolchain_c
 channel_sources:
-- conda-forge/label/gcc7,defaults
+- conda-forge,defaults
 channel_targets:
-- conda-forge gcc7
+- conda-forge main
 cxx_compiler:
-- clangxx
-hdf5:
-- 1.10.4
+- toolchain_cxx
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+mpi:
+- openmpi
 pin_run_as_build:
   bzip2:
     max_pin: x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2
 
 jobs:
-  build_linux_c_compilergcccxx_compilergxxtarget_platformlinux-64:
+  build_linux_c_compilergcccxx_compilergxxmpimpichtarget_platformlinux-64:
     working_directory: ~/test
     machine: true
     environment:
-      - CONFIG: "linux_c_compilergcccxx_compilergxxtarget_platformlinux-64"
+      - CONFIG: "linux_c_compilergcccxx_compilergxxmpimpichtarget_platformlinux-64"
     steps:
       - checkout
       - run:
@@ -18,11 +18,79 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./.circleci/run_docker_build.sh
-  build_linux_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformlinux-64:
+  build_linux_c_compilergcccxx_compilergxxmpinompitarget_platformlinux-64:
     working_directory: ~/test
     machine: true
     environment:
-      - CONFIG: "linux_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformlinux-64"
+      - CONFIG: "linux_c_compilergcccxx_compilergxxmpinompitarget_platformlinux-64"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_c_compilergcccxx_compilergxxmpiopenmpitarget_platformlinux-64:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_c_compilergcccxx_compilergxxmpiopenmpitarget_platformlinux-64"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpimpichtarget_platformlinux-64:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpimpichtarget_platformlinux-64"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpinompitarget_platformlinux-64:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpinompitarget_platformlinux-64"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpiopenmpitarget_platformlinux-64:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpiopenmpitarget_platformlinux-64"
     steps:
       - checkout
       - run:
@@ -40,5 +108,9 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build_linux_c_compilergcccxx_compilergxxtarget_platformlinux-64
-      - build_linux_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformlinux-64
+      - build_linux_c_compilergcccxx_compilergxxmpimpichtarget_platformlinux-64
+      - build_linux_c_compilergcccxx_compilergxxmpinompitarget_platformlinux-64
+      - build_linux_c_compilergcccxx_compilergxxmpiopenmpitarget_platformlinux-64
+      - build_linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpimpichtarget_platformlinux-64
+      - build_linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpinompitarget_platformlinux-64
+      - build_linux_c_compilertoolchain_ccxx_compilertoolchain_cxxmpiopenmpitarget_platformlinux-64

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,12 @@ osx_image: xcode9.4
 
 env:
   matrix:
-    - CONFIG=osx_c_compilerclangcxx_compilerclangxxtarget_platformosx-64
-    - CONFIG=osx_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformosx-64
+    - CONFIG=osx_c_compilerclangcxx_compilerclangxxmpimpichtarget_platformosx-64
+    - CONFIG=osx_c_compilerclangcxx_compilerclangxxmpinompitarget_platformosx-64
+    - CONFIG=osx_c_compilerclangcxx_compilerclangxxmpiopenmpitarget_platformosx-64
+    - CONFIG=osx_c_compilertoolchain_ccxx_compilertoolchain_cxxmpimpichtarget_platformosx-64
+    - CONFIG=osx_c_compilertoolchain_ccxx_compilertoolchain_cxxmpinompitarget_platformosx-64
+    - CONFIG=osx_c_compilertoolchain_ccxx_compilertoolchain_cxxmpiopenmpitarget_platformosx-64
 
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,6 +19,13 @@ export CFLAGS="${CFLAGS} -fPIC"
 #   also forces taking conda-forge libtool
 autoreconf -vfi
 
+# MPI variants
+if [[ ${mpi} == "nompi" ]]; then
+   export ADIOS_MPI="--without-mpi"
+else
+   export ADIOS_MPI="--with-mpi=${PREFIX}"
+fi
+
 ./configure --prefix=${PREFIX} \
             --with-pic \
             --enable-static \
@@ -32,7 +39,7 @@ autoreconf -vfi
             --without-sz \
             --without-szip \
             --without-zfp \
-            --without-mpi
+            ${ADIOS_MPI}
 
 # TODO nice to have
 # libtool error:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,8 @@
+mpi:
+- nompi
+- mpich
+- openmpi
+
 # we only need some python scripts executed during build
 python:
  - 3.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,15 @@
 {% set name = "adios" %}
+{% set build = 1009 %}
 {% set version = "1.13.1" %}
 {% set sha256 = "684096cd7e5a7f6b8859601d4daeb1dfaa416dfc2d9d529158a62df6c5bcd7a0" %}
+
+# ensure mpi is defined (needed for conda-smithy recipe-lint)
+{% set mpi = mpi or 'nompi' %}
+
+# prioritize nompi variant via build number
+{% if mpi == 'nompi' %}
+{% set build = build + 100 %}
+{% endif %}
 
 package:
   name: {{ name|lower }}
@@ -15,7 +24,26 @@ source:
     - python3interp.patch
 
 build:
-  number: 1008
+  number: {{ build }}
+
+  # add build string so packages can depend on
+  # mpi or nompi variants
+  # dependencies:
+  # `pkg * mpi_mpich_*` for mpich
+  # `pkg * mpi_*` for any mpi
+  # `pkg * nompi_*` for no mpi
+
+  {% if mpi == 'nompi' %}
+  {% set mpi_prefix = "nompi" %}
+  {% else %}
+  {% set mpi_prefix = "mpi_" + mpi %}
+  {% endif %}
+  string: "{{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}"
+
+  # strict runtime dependency on variant's MPI
+  run_exports:
+    - {{ name }} * {{ mpi_prefix }}_*
+
   skip: True  # [win]
 
 requirements:
@@ -30,14 +58,18 @@ requirements:
     - libtool
     - pkg-config
   host:
+    - {{ mpi }}  # [mpi != 'nompi']
     - blosc
     - bzip2
-    - hdf5
+#   - hdf5
+#   - hdf5 * mpi_{{ mpi }}_*  # [mpi != 'nompi']
     - zlib
   run:
+    - {{ mpi }}  # [mpi != "nompi"]
     - blosc
     - bzip2
-    - hdf5
+#   - hdf5
+#   - hdf5 * mpi_{{ mpi }}_*  # [mpi != 'nompi']
     - zlib
 
 test:


### PR DESCRIPTION
Close #11 

[TL;DR](https://github.com/conda-forge/adios-feedstock/pull/12#discussion_r245610080)

> allows users to make the following installation choices:
>
> - `conda install adios` installs by default the nompi variant
> - `conda install adios=*=mpi*` installs any mpi-compatible implementation
> - `conda install adios=*=mpi_mpich*` explicitly picks mpich variant. This will have the same result as `conda install mpich adios=*=mpi*`
>  - `conda install adios=1.13=nompi*` explicitly forbids mpi. Usually not necessary, as the build number offset will cause nompi to be preferred unless mpi is explicitly requested.

- [x] looks like the `nompi` variant is missing in the compile matrix of the CIs after rendering
- [x] re-render against pinning `2018.11.13` or newer