### PR TITLE
Always -rpath-link

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 if [[ ${target_platform} =~ osx.* ]]; then
-    export LDFLAGS="${LDFLAGS} -Wl,-rpath,$PREFIX/lib"
-else
-    export LDFLAGS="${LDFLAGS} -Wl,-rpath-link,${PREFIX}/lib"
+    export LDFLAGS="${LDFLAGS} -Wl,-rpath,${PREFIX}/lib"
 fi
+
+export LDFLAGS="${LDFLAGS} -Wl,-rpath-link,${PREFIX}/lib"
 
 # Python3 fixes
 if [[ "${PY_VER}" =~ 3 ]]
@@ -24,9 +24,9 @@ autoreconf -vfi
             --enable-static \
             --enable-shared \
             --disable-fortran \
-            --with-blosc=$PREFIX \
-            --with-bzip2=$PREFIX \
-            --with-zlib=$PREFIX \
+            --with-blosc=${PREFIX} \
+            --with-bzip2=${PREFIX} \
+            --with-zlib=${PREFIX} \
             --without-hdf5 \
             --without-phdf5 \
             --without-sz \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - python3interp.patch
 
 build:
-  number: 1007
+  number: 1008
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
Experiment to always set `-rpath-link` on all build libs.
Should make the conda-provided compilers' outputs more robust.

Hopefully helps with https://github.com/conda-forge/openpmd-api-feedstock/pull/13

Related to https://github.com/conda-forge/adios-feedstock/pull/7#issuecomment-438248294