### PR TITLE
Static Libs: No run_exports

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -6,18 +6,18 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      osx_c_compilerclangfortran_compilergfortranmpimpichtarget_platformosx-64:
-        CONFIG: osx_c_compilerclangfortran_compilergfortranmpimpichtarget_platformosx-64
-      osx_c_compilerclangfortran_compilergfortranmpinompitarget_platformosx-64:
-        CONFIG: osx_c_compilerclangfortran_compilergfortranmpinompitarget_platformosx-64
-      osx_c_compilerclangfortran_compilergfortranmpiopenmpitarget_platformosx-64:
-        CONFIG: osx_c_compilerclangfortran_compilergfortranmpiopenmpitarget_platformosx-64
-      osx_c_compilertoolchain_cfortran_compilertoolchain_fortmpimpichtarget_platformosx-64:
-        CONFIG: osx_c_compilertoolchain_cfortran_compilertoolchain_fortmpimpichtarget_platformosx-64
-      osx_c_compilertoolchain_cfortran_compilertoolchain_fortmpinompitarget_platformosx-64:
-        CONFIG: osx_c_compilertoolchain_cfortran_compilertoolchain_fortmpinompitarget_platformosx-64
-      osx_c_compilertoolchain_cfortran_compilertoolchain_fortmpiopenmpitarget_platformosx-64:
-        CONFIG: osx_c_compilertoolchain_cfortran_compilertoolchain_fortmpiopenmpitarget_platformosx-64
+      osx_c_compilerclangcxx_compilerclangxxfortran_compilergfortranmpimpichtarget_platformosx-64:
+        CONFIG: osx_c_compilerclangcxx_compilerclangxxfortran_compilergfortranmpimpichtarget_platformosx-64
+      osx_c_compilerclangcxx_compilerclangxxfortran_compilergfortranmpinompitarget_platformosx-64:
+        CONFIG: osx_c_compilerclangcxx_compilerclangxxfortran_compilergfortranmpinompitarget_platformosx-64
+      osx_c_compilerclangcxx_compilerclangxxfortran_compilergfortranmpiopenmpitarget_platformosx-64:
+        CONFIG: osx_c_compilerclangcxx_compilerclangxxfortran_compilergfortranmpiopenmpitarget_platformosx-64
+      osx_c_compilertoolchain_ccxx_compilertoolchain_cxxfortran_compilertoolchain_fortmpimpichtarget_platformosx-64:
+        CONFIG: osx_c_compilertoolchain_ccxx_compilertoolchain_cxxfortran_compilertoolchain_fortmpimpichtarget_platformosx-64
+      osx_c_compilertoolchain_ccxx_compilertoolchain_cxxfortran_compilertoolchain_fortmpinompitarget_platformosx-64:
+        CONFIG: osx_c_compilertoolchain_ccxx_compilertoolchain_cxxfortran_compilertoolchain_fortmpinompitarget_platformosx-64
+      osx_c_compilertoolchain_ccxx_compilertoolchain_cxxfortran_compilertoolchain_fortmpiopenmpitarget_platformosx-64:
+        CONFIG: osx_c_compilertoolchain_ccxx_compilertoolchain_cxxfortran_compilertoolchain_fortmpiopenmpitarget_platformosx-64
 
   steps:
   # TODO: Fast finish on azure pipelines?

--- a/.ci_support/linux_c_compilergccfortran_compilergfortranmpimpichtarget_platformlinux-64.yaml
+++ b/.ci_support/linux_c_compilergccfortran_compilergfortranmpimpichtarget_platformlinux-64.yaml
@@ -17,8 +17,13 @@ mpi:
 pin_run_as_build:
   bzip2:
     max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- '3.6'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_c_compilergccfortran_compilergfortranmpinompitarget_platformlinux-64.yaml
+++ b/.ci_support/linux_c_compilergccfortran_compilergfortranmpinompitarget_platformlinux-64.yaml
@@ -17,8 +17,13 @@ mpi:
 pin_run_as_build:
   bzip2:
     max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- '3.6'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_c_compilergccfortran_compilergfortranmpiopenmpitarget_platformlinux-64.yaml
+++ b/.ci_support/linux_c_compilergccfortran_compilergfortranmpiopenmpitarget_platformlinux-64.yaml
@@ -17,8 +17,13 @@ mpi:
 pin_run_as_build:
   bzip2:
     max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- '3.6'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_c_compilertoolchain_cfortran_compilertoolchain_fortmpimpichtarget_platformlinux-64.yaml
+++ b/.ci_support/linux_c_compilertoolchain_cfortran_compilertoolchain_fortmpimpichtarget_platformlinux-64.yaml
@@ -17,8 +17,13 @@ mpi:
 pin_run_as_build:
   bzip2:
     max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- '3.6'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_c_compilertoolchain_cfortran_compilertoolchain_fortmpinompitarget_platformlinux-64.yaml
+++ b/.ci_support/linux_c_compilertoolchain_cfortran_compilertoolchain_fortmpinompitarget_platformlinux-64.yaml
@@ -17,8 +17,13 @@ mpi:
 pin_run_as_build:
   bzip2:
     max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- '3.6'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_c_compilertoolchain_cfortran_compilertoolchain_fortmpiopenmpitarget_platformlinux-64.yaml
+++ b/.ci_support/linux_c_compilertoolchain_cfortran_compilertoolchain_fortmpiopenmpitarget_platformlinux-64.yaml
@@ -17,8 +17,13 @@ mpi:
 pin_run_as_build:
   bzip2:
     max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- '3.6'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/osx_c_compilerclangcxx_compilerclangxxfortran_compilergfortranmpimpichtarget_platformosx-64.yaml
+++ b/.ci_support/osx_c_compilerclangcxx_compilerclangxxfortran_compilergfortranmpimpichtarget_platformosx-64.yaml
@@ -1,17 +1,19 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 build_number_decrement:
-- '1000'
+- '0'
 bzip2:
 - '1'
 c_compiler:
-- toolchain_c
+- clang
 channel_sources:
-- conda-forge,defaults
+- conda-forge/label/gcc7,defaults
 channel_targets:
-- conda-forge main
+- conda-forge gcc7
+cxx_compiler:
+- clangxx
 fortran_compiler:
-- toolchain_fort
+- gfortran
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -21,12 +23,18 @@ mpi:
 pin_run_as_build:
   bzip2:
     max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- '3.6'
 target_platform:
 - osx-64
 zip_keys:
 - - c_compiler
+  - cxx_compiler
   - fortran_compiler
   - channel_sources
   - channel_targets

--- a/.ci_support/osx_c_compilerclangcxx_compilerclangxxfortran_compilergfortranmpinompitarget_platformosx-64.yaml
+++ b/.ci_support/osx_c_compilerclangcxx_compilerclangxxfortran_compilergfortranmpinompitarget_platformosx-64.yaml
@@ -10,6 +10,8 @@ channel_sources:
 - conda-forge/label/gcc7,defaults
 channel_targets:
 - conda-forge gcc7
+cxx_compiler:
+- clangxx
 fortran_compiler:
 - gfortran
 macos_machine:
@@ -17,16 +19,22 @@ macos_machine:
 macos_min_version:
 - '10.9'
 mpi:
-- mpich
+- nompi
 pin_run_as_build:
   bzip2:
     max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- '3.6'
 target_platform:
 - osx-64
 zip_keys:
 - - c_compiler
+  - cxx_compiler
   - fortran_compiler
   - channel_sources
   - channel_targets

--- a/.ci_support/osx_c_compilerclangcxx_compilerclangxxfortran_compilergfortranmpiopenmpitarget_platformosx-64.yaml
+++ b/.ci_support/osx_c_compilerclangcxx_compilerclangxxfortran_compilergfortranmpiopenmpitarget_platformosx-64.yaml
@@ -1,32 +1,40 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 build_number_decrement:
-- '1000'
+- '0'
 bzip2:
 - '1'
 c_compiler:
-- toolchain_c
+- clang
 channel_sources:
-- conda-forge,defaults
+- conda-forge/label/gcc7,defaults
 channel_targets:
-- conda-forge main
+- conda-forge gcc7
+cxx_compiler:
+- clangxx
 fortran_compiler:
-- toolchain_fort
+- gfortran
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 mpi:
-- nompi
+- openmpi
 pin_run_as_build:
   bzip2:
     max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- '3.6'
 target_platform:
 - osx-64
 zip_keys:
 - - c_compiler
+  - cxx_compiler
   - fortran_compiler
   - channel_sources
   - channel_targets

--- a/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxfortran_compilertoolchain_fortmpimpichtarget_platformosx-64.yaml
+++ b/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxfortran_compilertoolchain_fortmpimpichtarget_platformosx-64.yaml
@@ -10,6 +10,8 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- toolchain_cxx
 fortran_compiler:
 - toolchain_fort
 macos_machine:
@@ -17,16 +19,22 @@ macos_machine:
 macos_min_version:
 - '10.9'
 mpi:
-- openmpi
+- mpich
 pin_run_as_build:
   bzip2:
     max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- '3.6'
 target_platform:
 - osx-64
 zip_keys:
 - - c_compiler
+  - cxx_compiler
   - fortran_compiler
   - channel_sources
   - channel_targets

--- a/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxfortran_compilertoolchain_fortmpinompitarget_platformosx-64.yaml
+++ b/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxfortran_compilertoolchain_fortmpinompitarget_platformosx-64.yaml
@@ -1,32 +1,40 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 build_number_decrement:
-- '0'
+- '1000'
 bzip2:
 - '1'
 c_compiler:
-- clang
+- toolchain_c
 channel_sources:
-- conda-forge/label/gcc7,defaults
+- conda-forge,defaults
 channel_targets:
-- conda-forge gcc7
+- conda-forge main
+cxx_compiler:
+- toolchain_cxx
 fortran_compiler:
-- gfortran
+- toolchain_fort
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 mpi:
-- openmpi
+- nompi
 pin_run_as_build:
   bzip2:
     max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- '3.6'
 target_platform:
 - osx-64
 zip_keys:
 - - c_compiler
+  - cxx_compiler
   - fortran_compiler
   - channel_sources
   - channel_targets

--- a/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxfortran_compilertoolchain_fortmpiopenmpitarget_platformosx-64.yaml
+++ b/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxfortran_compilertoolchain_fortmpiopenmpitarget_platformosx-64.yaml
@@ -1,32 +1,40 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 build_number_decrement:
-- '0'
+- '1000'
 bzip2:
 - '1'
 c_compiler:
-- clang
+- toolchain_c
 channel_sources:
-- conda-forge/label/gcc7,defaults
+- conda-forge,defaults
 channel_targets:
-- conda-forge gcc7
+- conda-forge main
+cxx_compiler:
+- toolchain_cxx
 fortran_compiler:
-- gfortran
+- toolchain_fort
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 mpi:
-- nompi
+- openmpi
 pin_run_as_build:
   bzip2:
     max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
   zlib:
     max_pin: x.x
+python:
+- '3.6'
 target_platform:
 - osx-64
 zip_keys:
 - - c_compiler
+  - cxx_compiler
   - fortran_compiler
   - channel_sources
   - channel_targets

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ osx_image: xcode9.4
 
 env:
   matrix:
-    - CONFIG=osx_c_compilerclangfortran_compilergfortranmpimpichtarget_platformosx-64
-    - CONFIG=osx_c_compilerclangfortran_compilergfortranmpinompitarget_platformosx-64
-    - CONFIG=osx_c_compilerclangfortran_compilergfortranmpiopenmpitarget_platformosx-64
-    - CONFIG=osx_c_compilertoolchain_cfortran_compilertoolchain_fortmpimpichtarget_platformosx-64
-    - CONFIG=osx_c_compilertoolchain_cfortran_compilertoolchain_fortmpinompitarget_platformosx-64
-    - CONFIG=osx_c_compilertoolchain_cfortran_compilertoolchain_fortmpiopenmpitarget_platformosx-64
+    - CONFIG=osx_c_compilerclangcxx_compilerclangxxfortran_compilergfortranmpimpichtarget_platformosx-64
+    - CONFIG=osx_c_compilerclangcxx_compilerclangxxfortran_compilergfortranmpinompitarget_platformosx-64
+    - CONFIG=osx_c_compilerclangcxx_compilerclangxxfortran_compilergfortranmpiopenmpitarget_platformosx-64
+    - CONFIG=osx_c_compilertoolchain_ccxx_compilertoolchain_cxxfortran_compilertoolchain_fortmpimpichtarget_platformosx-64
+    - CONFIG=osx_c_compilertoolchain_ccxx_compilertoolchain_cxxfortran_compilertoolchain_fortmpinompitarget_platformosx-64
+    - CONFIG=osx_c_compilertoolchain_ccxx_compilertoolchain_cxxfortran_compilertoolchain_fortmpiopenmpitarget_platformosx-64
 
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "adios" %}
-{% set build = 1010 %}
+{% set build = 1011 %}
 {% set version = "1.13.1" %}
 {% set sha256 = "684096cd7e5a7f6b8859601d4daeb1dfaa416dfc2d9d529158a62df6c5bcd7a0" %}
 
@@ -41,9 +41,10 @@ build:
   {% endif %}
   string: "{{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}"
 
-  # strict runtime dependency on variant's MPI
-  run_exports:
-    - {{ name }} * {{ mpi_prefix }}_*
+  # if we were building shared libraries (we don't):
+  # strict runtime dependency on build-time MPI flavor
+  # run_exports:
+  #   - {{ name }} * {{ mpi_prefix }}_*
 
   skip: True  # [win]
 


### PR DESCRIPTION
exporting ADIOS' variant as runtime export is not needed as we only build static ADIOS libs (that forward shared dependencies via `adios_config` `.pc`/`pkgconfig` tooling).

https://github.com/conda-forge/adios-feedstock/pull/12/files#r247309803