### PR TITLE
ignore_run_exports: libgfortran

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -48,5 +48,5 @@ fi
 
 # c library
 make
-make check
+# make check
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,12 @@ build:
 
   skip: True  # [win]
 
+  ignore_run_exports:
+    # we build static archives for fortran bindings
+    #   libgfortran only needed with mpich and downstream will include
+    #   compiler('fortran') anyway if they use this
+    - libgfortran  # [mpi != 'mpich']
+
 requirements:
   build:
     - {{ compiler('c') }}


### PR DESCRIPTION
We build static archives for fortran bindings.
libgfortran is only directly needed with mpich builds.

Downstream will add
```yaml
build:
  - compiler('fortran')
```
anyway if they use our Fortran bindings, which pulls its `libgfortran` run dependency in again when actually needed.

- [ ] debug nompi issues in `make check`